### PR TITLE
Add Base.zero, Grassmann.invretract, and Grassmann.matchgauge

### DIFF
--- a/src/TensorKitManifolds.jl
+++ b/src/TensorKitManifolds.jl
@@ -4,7 +4,7 @@ export base, checkbase, isisometry, isunitary
 export projecthermitian, projecthermitian!, projectantihermitian, projectantihermitian!
 export projectcomplement, projectcomplement!, projectisometric, projectisometric!
 export Grassmann, Stiefel, Unitary
-export inner, retract, invretract, transport, transport!
+export inner, retract, transport, transport!
 
 using TensorKit
 
@@ -19,7 +19,6 @@ using TensorKit
 # which too should accept a keyword argument `metric`, even if it is ignored.
 function inner end
 function retract end
-function invretract end
 function transport end
 function transport! end
 function base end

--- a/src/grassmann.jl
+++ b/src/grassmann.jl
@@ -161,6 +161,42 @@ function retract(W::AbstractTensorMap, Δ::GrassmannTangent, α; alg = nothing)
     return W′, GrassmannTangent(W′, Z′)
 end
 
+"""
+    invretract(Wold::AbstractTensorMap, Wnew::AbstractTensorMap; alg = nothing)
+
+Return the Grassmann tangent Z and unitary Y such that `retract(Wold, Z, 1) * Y ≈ Wnew`.
+
+This is done by solving the equation `Wold * V * cos(S) * V' + U * sin(S) * V' = Wnew * Y`
+for the isometries V, U, and Y, and the diagonal matrix S, and returning Z, Y, where
+`Z = U * S * V'`.
+"""
+function invretract(Wold::AbstractTensorMap, Wnew::AbstractTensorMap; alg = nothing)
+    space(Wold) == space(Wnew) || throw(SectorMismatch())
+    WodWn = Wold' * Wnew
+    res = Wnew - Wold * WodWn
+    V, cS, Xd = tsvd!(WodWn)
+    Scmplx = acos(cS)
+    # acos always returns a complex TensorMap. We cast back to real if possible.
+    S = eltype(WodWn) <: Real ? real(Scmplx) : Scmplx
+    u, s, vd = tsvd!(res * Xd' * sin(S))
+    Z = Grassmann.GrassmannTangent(Wold, u * vd * S * V')
+    Y = V * Xd
+    return Z, Y
+end
+
+"""
+    matchgauge(W::AbstractTensorMap, V::AbstractTensorMap)
+
+Return the unitary Y such that V*Y and W are "in the same Grassmann gauge", in the sense
+that they can be connected by a Grassmann retraction.
+"""
+function matchgauge(W::AbstractTensorMap, V::AbstractTensorMap)
+    space(W) == space(V) || throw(SectorMismatch())
+    WdV = W' * V
+    u, s, v = tsvd!(WdV)
+    return v' * u'
+end
+
 function transport!(Θ::GrassmannTangent, W::AbstractTensorMap, Δ::GrassmannTangent, α, W′;
                     alg = nothing)
     W == checkbase(Δ,Θ) || throw(ArgumentError("not a valid tangent vector at base point"))

--- a/src/grassmann.jl
+++ b/src/grassmann.jl
@@ -94,6 +94,8 @@ Base.:*(α::Number, Δ::GrassmannTangent) = lmul!(α, copy(Δ))
 Base.:/(Δ::GrassmannTangent, α::Number) = rmul!(copy(Δ), inv(α))
 Base.:\(α::Number, Δ::GrassmannTangent) = lmul!(inv(α), copy(Δ))
 
+Base.zero(Δ::GrassmannTangent) = GrassmannTangent(Δ.W, zero(Δ.Z))
+
 function TensorKit.rmul!(Δ::GrassmannTangent, α::Number)
     rmul!(Δ.Z, α)
     if Base.getfield(Δ, :S) !== nothing

--- a/src/stiefel.jl
+++ b/src/stiefel.jl
@@ -10,7 +10,7 @@ using ..TensorKitManifolds: projecthermitian!, projectantihermitian!,
                             projectisometric!, projectcomplement!, PolarNewton,
                             _stiefelexp, _stiefellog, eleps
 import ..TensorKitManifolds: base, checkbase,
-                                inner, retract, invretract, transport, transport!
+                                inner, retract, transport, transport!
 
 # special type to store tangent vectors using A and Z = Q*R,
 mutable struct StiefelTangent{T<:AbstractTensorMap, TA<:AbstractTensorMap}

--- a/src/stiefel.jl
+++ b/src/stiefel.jl
@@ -40,6 +40,8 @@ Base.:*(α::Real, Δ::StiefelTangent) = lmul!(α, copy(Δ))
 Base.:/(Δ::StiefelTangent, α::Real) = rmul!(copy(Δ), inv(α))
 Base.:\(α::Real, Δ::StiefelTangent) = lmul!(inv(α), copy(Δ))
 
+Base.zero(Δ::StiefelTangent) = StiefelTangent(Δ.W, zero(Δ.A), zero(Δ.Z))
+
 function TensorKit.rmul!(Δ::StiefelTangent, α::Real)
     rmul!(Δ.A, α)
     rmul!(Δ.Z, α)

--- a/src/unitary.jl
+++ b/src/unitary.jl
@@ -47,6 +47,8 @@ Base.:*(α::Real, Δ::UnitaryTangent) = lmul!(α, copy(Δ))
 Base.:/(Δ::UnitaryTangent, α::Real) = rmul!(copy(Δ), inv(α))
 Base.:\(α::Real, Δ::UnitaryTangent) = lmul!(inv(α), copy(Δ))
 
+Base.zero(Δ::UnitaryTangent) = UnitaryTangent(Δ.W, zero(Δ.A))
+
 function TensorKit.rmul!(Δ::UnitaryTangent, α::Real)
     rmul!(Δ.A, α)
     return Δ

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -39,6 +39,13 @@ const α = 0.75
         @test Ξ2[] ≈ -Δ2[] + γ * Θ2[]
         @test Grassmann.inner(W2, Δ2, Θ2) ≈ Grassmann.inner(W, Δ, Θ)
         @test Grassmann.inner(W2, Ξ2, Θ2) ≈ Grassmann.inner(W, Ξ, Θ)
+
+        Wend = TensorMap(randhaar, T, codomain(W), domain(W))
+        Δ3, V = Grassmann.invretract(W, Wend)
+        @test Wend ≈ retract(W, Δ3, 1)[1] * V
+        U = Grassmann.matchgauge(W, Wend)
+        V2 = Grassmann.invretract(W, Wend * U)[2]
+        @test V2 ≈ one(V2)
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,6 +17,7 @@ const α = 0.75
         @test norm(W'*Δ[]) <= sqrt(eps(real(T)))*dim(domain(W))
         @test norm(W'*Θ[]) <= sqrt(eps(real(T)))*dim(domain(W))
         @test norm(W'*Ξ[]) <= sqrt(eps(real(T)))*dim(domain(W))
+        @test norm(zero(W)) == 0
         @test (@inferred Grassmann.inner(W, Δ, Θ)) ≈ real(dot(Δ[], Θ[]))
         @test Grassmann.inner(W, Δ, Θ) ≈ real(dot(X, Θ[]))
         @test Grassmann.inner(W, Δ, Θ) ≈ real(dot(Δ[],Y))
@@ -53,6 +54,7 @@ end
         @test norm(W'*Δ[] + Δ[]'*W) <= sqrt(eps(real(T)))*dim(domain(W))
         @test norm(W'*Θ[] + Θ[]'*W) <= sqrt(eps(real(T)))*dim(domain(W))
         @test norm(W'*Ξ[] + Ξ[]'*W) <= sqrt(eps(real(T)))*dim(domain(W))
+        @test norm(zero(W)) == 0
         @test (@inferred Stiefel.inner_euclidean(W, Δ, Θ)) ≈ real(dot(Δ[], Θ[]))
         @test (@inferred Stiefel.inner_canonical(W, Δ, Θ)) ≈
                                                         real(dot(Δ[], Θ[] - W*(W'*Θ[])/2))
@@ -116,6 +118,7 @@ end
         @test norm(W'*Δ[] + Δ[]'*W) <= sqrt(eps(real(T)))*dim(domain(W))
         @test norm(W'*Θ[] + Θ[]'*W) <= sqrt(eps(real(T)))*dim(domain(W))
         @test norm(W'*Ξ[] + Ξ[]'*W) <= sqrt(eps(real(T)))*dim(domain(W))
+        @test norm(zero(W)) == 0
         @test (@inferred Unitary.inner(W, Δ, Θ)) ≈ real(dot(Δ[], Θ[]))
         @test Unitary.inner(W, Δ, Θ) ≈ real(dot(X, Θ[]))
         @test Unitary.inner(W, Δ, Θ) ≈ real(dot(Δ[],Y))


### PR DESCRIPTION
I also ended up removing the global `invretract` since I think it should be specific to Stiefel/Grassmann/Unitary, just like e.g. `project`. I guess that makes this a breaking change, at least in principle.

Also, I tried adding a test for `Stiefel.invretract` too, but it errored in `_stiefellog` with
`AssertionError: mapreduce(abs ∘ imag, max, logU; init = abs(zero(eltype(logU)))) <= tol`
I could look into this, but maybe you know what's going on already?