### PR TITLE
Tensorkit v0.13

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6' # LTS version
+          - 'lts' # LTS version
           - '1' # automatically expands to the latest stable 1.x release of Julia
         os:
           - ubuntu-latest
@@ -29,10 +29,6 @@ jobs:
           - windows-latest
         arch:
           - x64
-        #   - x86
-        # exclude:
-        #   - os: macOS-latest
-        #     arch: x86
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2

--- a/Project.toml
+++ b/Project.toml
@@ -1,14 +1,14 @@
 name = "TensorKitManifolds"
 uuid = "11fa318c-39cb-4a83-b1ed-cdc7ba1e3684"
 authors = ["Jutho Haegeman <jutho.haegeman@ugent.be>", "Markus Hauru <markus@mhauru.org>"]
-version = "0.7"
+version = "0.7.1"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 TensorKit = "07d1fe3e-3e46-537d-9eac-e9e13d0d4cec"
 
 [compat]
-TensorKit = "0.12.1"
+TensorKit = "0.13"
 julia = "1.6"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ TensorKit = "07d1fe3e-3e46-537d-9eac-e9e13d0d4cec"
 
 [compat]
 TensorKit = "0.13"
-julia = "1.6"
+julia = "1.10"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/grassmann.jl
+++ b/src/grassmann.jl
@@ -22,8 +22,8 @@ mutable struct GrassmannTangent{T<:AbstractTensorMap,
     U::Union{Nothing,TU}
     S::Union{Nothing,TS}
     V::Union{Nothing,TV}
-    function GrassmannTangent(W::AbstractTensorMap{S,N₁,N₂},
-                              Z::AbstractTensorMap{S,N₁,N₂}) where {S,N₁,N₂}
+    function GrassmannTangent(W::AbstractTensorMap{TT₁,S,N₁,N₂},
+                              Z::AbstractTensorMap{TT₂,S,N₁,N₂}) where {TT₁,TT₂,S,N₁,N₂}
         T = typeof(W)
         TT = promote_type(float(scalartype(W)), scalartype(Z))
         M = similarstoragetype(W, TT)

--- a/src/stiefel.jl
+++ b/src/stiefel.jl
@@ -167,24 +167,18 @@ function stiefelexp(W::AbstractTensorMap,
                     A::AbstractTensorMap,
                     Z::AbstractTensorMap,
                     α::Real)
-    S = spacetype(W)
-    G = sectortype(W)
-    dims = TensorKit.SectorDict{G,Int}()
-    generator = Iterators.map(blocks(W)) do (c, b)
+    V = fuse(domain(W))
+    W′ = similar(W)
+    Q = similar(W, codomain(W) ← V)
+    Q′ = similar(Q)
+    R′ = similar(W, V ← domain(W))
+    for (c, b) in blocks(W)
         w′, q, q′, r′ = _stiefelexp(b, block(A, c), block(Z, c), α)
-        dims[c] = size(q, 2)
-        return c => (w′, q, q′, r′)
+        copy!(block(W′, c), w′)
+        copy!(block(Q, c), q)
+        copy!(block(Q′, c), q′)
+        copy!(block(R′, c), r′)
     end
-    wqqr = TensorKit.SectorDict(generator)
-    Wdata′ = SectorDict(c => w′ for (c, (w′, q, q′, r′)) in wqqr)
-    Qdata = SectorDict(c => q for (c, (w′, q, q′, r′)) in wqqr)
-    Qdata′ = SectorDict(c => q′ for (c, (w′, q, q′, r′)) in wqqr)
-    Rdata′ = SectorDict(c => r′ for (c, (w′, q, q′, r′)) in wqqr)
-    V = S(dims)
-    W′ = TensorMap(Wdata′, space(W))
-    Q = TensorMap(Qdata, codomain(W) ← V)
-    Q′ = TensorMap(Qdata′, codomain(W) ← V)
-    R′ = TensorMap(Rdata′, V ← domain(W))
     return W′, Q, Q′, R′
 end
 

--- a/src/unitary.jl
+++ b/src/unitary.jl
@@ -11,8 +11,8 @@ import ..TensorKitManifolds: base, checkbase, inner, retract, transport, transpo
 struct UnitaryTangent{T<:AbstractTensorMap,TA<:AbstractTensorMap}
     W::T
     A::TA
-    function UnitaryTangent(W::AbstractTensorMap{S,N₁,N₂},
-                            A::AbstractTensorMap{S,N₂,N₂}) where {S,N₁,N₂}
+    function UnitaryTangent(W::AbstractTensorMap{T₁,S,N₁,N₂},
+                            A::AbstractTensorMap{T₂,S,N₂,N₂}) where {T₁,T₂,S,N₁,N₂}
         T = typeof(W)
         TA = typeof(A)
         return new{T,TA}(W, A)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,9 +8,9 @@ const α = 0.75
 
 @testset "Grassmann with space $V" for V in spaces
     for T in (Float64,)
-        W, = leftorth(TensorMap(randn, T, V * V * V, V * V); alg=Polar())
-        X = TensorMap(randn, T, space(W))
-        Y = TensorMap(randn, T, space(W))
+        W, = leftorth(randn(T, V * V * V, V * V); alg=Polar())
+        X = randn(T, space(W))
+        Y = randn(T, space(W))
         Δ = @inferred Grassmann.project(X, W)
         Θ = Grassmann.project(Y, W)
         γ = randn(T)
@@ -42,7 +42,7 @@ const α = 0.75
         @test Grassmann.inner(W2, Δ2, Θ2) ≈ Grassmann.inner(W, Δ, Θ)
         @test Grassmann.inner(W2, Ξ2, Θ2) ≈ Grassmann.inner(W, Ξ, Θ)
 
-        Wend = TensorMap(randhaar, T, codomain(W), domain(W))
+        Wend = randisometry(T, codomain(W), domain(W))
         Δ3, V = Grassmann.invretract(W, Wend)
         @test Wend ≈ retract(W, Δ3, 1)[1] * V
         U = Grassmann.relativegauge(W, Wend)
@@ -53,9 +53,9 @@ end
 
 @testset "Stiefel with space $V" for V in spaces
     for T in (Float64, ComplexF64)
-        W = TensorMap(randhaar, T, V * V * V, V * V)
-        X = TensorMap(randn, T, space(W))
-        Y = TensorMap(randn, T, space(W))
+        W = randisometry(T, V * V * V, V * V)
+        X = randn(T, space(W))
+        Y = randn(T, space(W))
         Δ = @inferred Stiefel.project_euclidean(X, W)
         Θ = Stiefel.project_canonical(Y, W)
         γ = rand()
@@ -116,7 +116,7 @@ end
         @test Stiefel.inner_canonical(W2, Δ2, Θ2) ≈ Stiefel.inner_canonical(W, Δ, Θ)
         @test Stiefel.inner_canonical(W2, Ξ2, Θ2) ≈ Stiefel.inner_canonical(W, Ξ, Θ)
 
-        W3 = projectisometric!(W + 1e-1 * TensorMap(rand, T, codomain(W), domain(W)))
+        W3 = projectisometric!(W + 1e-1 * rand(T, codomain(W), domain(W)))
         Δ3 = Stiefel.invretract(W, W3)
         @test W3 ≈ retract(W, Δ3, 1)[1]
     end
@@ -124,9 +124,9 @@ end
 
 @testset "Unitary with space $V" for V in spaces
     for T in (Float64, ComplexF64)
-        W, = leftorth(TensorMap(randn, T, V * V * V, V * V); alg=Polar())
-        X = TensorMap(randn, T, space(W))
-        Y = TensorMap(randn, T, space(W))
+        W, = leftorth(randn(T, V * V * V, V * V); alg=Polar())
+        X = randn(T, space(W))
+        Y = randn(T, space(W))
         Δ = @inferred Unitary.project(X, W)
         Θ = Unitary.project(Y, W)
         γ = randn()


### PR DESCRIPTION
This bumps the TensorKit compatibility to v0.13.
As this does not change any functionality, I opted to only bump the minor version, as otherwise everything should be backwards compatible.