### PR TITLE
Adapt to TensorKit v0.15

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,14 +1,16 @@
 name = "TensorKitManifolds"
 uuid = "11fa318c-39cb-4a83-b1ed-cdc7ba1e3684"
 authors = ["Jutho Haegeman <jutho.haegeman@ugent.be>", "Markus Hauru <markus@mhauru.org>"]
-version = "0.7.2"
+version = "0.7.3"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+MatrixAlgebraKit = "6c742aac-3347-4629-af66-fc926824e5e4"
 TensorKit = "07d1fe3e-3e46-537d-9eac-e9e13d0d4cec"
 
 [compat]
-TensorKit = "0.13,0.14"
+MatrixAlgebraKit = "0.5.0"
+TensorKit = "0.15"
 julia = "1.10"
 
 [extras]

--- a/src/grassmann.jl
+++ b/src/grassmann.jl
@@ -60,7 +60,7 @@ function Base.getproperty(Δ::GrassmannTangent, sym::Symbol)
     elseif sym ∈ (:U, :S, :V)
         v = Base.getfield(Δ, sym)
         v !== nothing && return v
-        U, S, V, = tsvd(Δ.Z; alg=default_svd_alg(Δ.Z))
+        U, S, V, = svd_compact(Δ.Z)
         Base.setfield!(Δ, :U, U)
         Base.setfield!(Δ, :S, S)
         Base.setfield!(Δ, :V, V)
@@ -198,7 +198,7 @@ function invretract(Wold::AbstractTensorMap, Wnew::AbstractTensorMap; alg=nothin
     space(Wold) == space(Wnew) || throw(SpaceMismatch())
     WodWn = Wold' * Wnew # V' * cos(S) * V * Y
     Wneworth = Wnew - Wold * WodWn
-    Vd, cS, VY = tsvd!(WodWn; alg=default_svd_alg(WodWn))
+    Vd, cS, VY = svd_compact!(WodWn)
     Scmplx = acos(cS)
     # acos always returns a complex TensorMap. We cast back to real if possible.
     S = scalartype(WodWn) <: Real && isreal(sectortype(Scmplx)) ? real(Scmplx) : Scmplx

--- a/src/unitary.jl
+++ b/src/unitary.jl
@@ -7,6 +7,7 @@ using TensorKit
 import TensorKit: similarstoragetype, SectorDict
 using ..TensorKitManifolds: projectantihermitian!, projectisometric!, PolarNewton
 import ..TensorKitManifolds: base, checkbase, inner, retract, transport, transport!
+import MatrixAlgebraKit as MAK
 
 struct UnitaryTangent{T<:AbstractTensorMap,TA<:AbstractTensorMap}
     W::T
@@ -82,10 +83,10 @@ end
 project(X, W; metric=:euclidean) = project!(copy(X), W; metric=:euclidean)
 
 # geodesic retraction, coincides with Stiefel retraction (which is not geodesic for p < n)
-function retract(W::AbstractTensorMap, Δ::UnitaryTangent, α; alg=nothing)
+function retract(W::AbstractTensorMap, Δ::UnitaryTangent, α; alg=MAK.select_algorithm(left_polar!, W))
     W == base(Δ) || throw(ArgumentError("not a valid tangent vector at base point"))
     E = exp(α * Δ.A)
-    W′ = projectisometric!(W * E; alg=SDD())
+    W′ = projectisometric!(W * E; alg)
     A′ = Δ.A
     return W′, UnitaryTangent(W′, A′)
 end
@@ -104,7 +105,7 @@ function transport!(Θ::UnitaryTangent, W::AbstractTensorMap, Δ::UnitaryTangent
 end
 function transport(Θ::UnitaryTangent, W::AbstractTensorMap, Δ::UnitaryTangent, α::Real, W′;
                    alg=:stiefel)
-    return transport!(copy(Θ), W, Δ, α, W′; alg=alg)
+    return transport!(copy(Θ), W, Δ, α, W′; alg)
 end
 
 # transport_parallel correspondings to the torsion-free Levi-Civita connection

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,7 +8,7 @@ const α = 0.75
 
 @testset "Grassmann with space $V" for V in spaces
     for T in (Float64,)
-        W, = leftorth(randn(T, V * V * V, V * V); alg=Polar())
+        W, = left_polar(randn(T, V * V * V, V * V))
         X = randn(T, space(W))
         Y = randn(T, space(W))
         Δ = @inferred Grassmann.project(X, W)
@@ -124,7 +124,7 @@ end
 
 @testset "Unitary with space $V" for V in spaces
     for T in (Float64, ComplexF64)
-        W, = leftorth(randn(T, V * V * V, V * V); alg=Polar())
+        W, = left_polar(randn(T, V * V * V, V * V))
         X = randn(T, space(W))
         Y = randn(T, space(W))
         Δ = @inferred Unitary.project(X, W)


### PR DESCRIPTION
This is a minimal set of changes needed to make this package compatible with TK v0.15.

In the long run, it might be nice to consider making some more substantial changes to further reduce the required code here, while migrating some of it to MatrixAlgebraKit.
I'm listing some of these suggestions here as a reminder:

- `PolarNewton` is an algorithm for computing the polar decomposition, which we can directly implement in MatrixAlgebraKit.
- `_left_polar!` could be replaced with `MatrixAlgebraKit.left_polar!` if we adopt a strategy that is similar to the one we have for QR decompositions -- providing an empty `R` to indicate that we do not wish to compute `R`.
- The various `project(anti)hermitian` functions might also be reasonable in `MatrixAlgebraKit`.

For now though, I'd prefer to just leave that for the future and get this merged, so also MPSKit can be updated.